### PR TITLE
fix the "player2 with keyboard" problem.

### DIFF
--- a/rpi/gp2xsdk.cpp
+++ b/rpi/gp2xsdk.cpp
@@ -282,7 +282,7 @@ int init_SDL(void)
         if(joy[0])
             logoutput("Found %d joysticks\n",joyCount);
     }
-    else
+    if(joyCount < 2)
         joyCount=2;
 
     //sq frig number of players for keyboard


### PR DESCRIPTION
The last change I made solve the problem for "no joysticks connected", but when the user has one, and only one, joystick connected, `joyCount` receives 1. Then, the player2 on keyboard doesn't work.
[this problem was reported here: https://retropie.org.uk/forum/topic/1914/has-anyone-got-a-keyboard-working-for-player-2-in-pifba/29]
This Pull Request solves this problem.
