### PR TITLE
RPI: use new vendor library names

### DIFF
--- a/FBAcapex_src/Makefile
+++ b/FBAcapex_src/Makefile
@@ -15,7 +15,7 @@ SDL_LIBS=-lSDL -lm -ldl -lglib-2.0
 
 CFLAGS = $(SDL_FLAGS) -O2 -funroll-loops -Wextra -Werror
 CXXFLAGS = $(SDL_FLAGS) -O2 -funroll-loops -Wall
-LIBS = $(SDL_LIBS)  -L/opt/vc/lib -lbcm_host -lGLESv2 -lrt
+LIBS = $(SDL_LIBS)  -L/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lrt
 
 TARGET = $(PROG_NAME)
 

--- a/FBAcapex_src/Makefile.debug
+++ b/FBAcapex_src/Makefile.debug
@@ -15,7 +15,7 @@ SDL_LIBS=-lSDL -lm -ldl -lglib-2.0
 
 CFLAGS = $(SDL_FLAGS) -g -funroll-loops -Wextra -Werror
 CXXFLAGS = $(SDL_FLAGS) -g -funroll-loops -Wall
-LIBS = $(SDL_LIBS)  -L/opt/vc/lib -lbcm_host -lGLESv2
+LIBS = $(SDL_LIBS)  -L/opt/vc/lib -lbcm_host -lbrcmGLESv2
 
 TARGET = $(PROG_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ INCPATH	= -I./rpi -I./burn -I./burn/neogeo -I./burn/capcom -I./burn/cave -I./bur
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux -I/usr/include/SDL -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include 
 LINK	= arm-linux-gnueabihf-g++
 LFLAGS	= 
-LIBS	= -lz -lpthread -lm -lpthread -lSDL -L/opt/vc/lib -lbcm_host -lGLESv2 -lEGL -lglib-2.0 -lasound -lrt
+LIBS	= -lz -lpthread -lm -lpthread -lSDL -L/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound -lrt
 
 TAR		= tar -cf
 GZIP	= gzip -9f

--- a/Makefile.debug
+++ b/Makefile.debug
@@ -24,7 +24,7 @@ INCPATH	= -I./rpi -I./burn -I./burn/neogeo -I./burn/capcom -I./burn/cave -I./bur
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux -I/usr/include/SDL -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include 
 LINK	= arm-linux-gnueabihf-g++
 LFLAGS	= -g
-LIBS	= -lz -lpthread -lm -lpthread -lSDL -L/opt/vc/lib -lbcm_host -lGLESv2 -lEGL -lglib-2.0 -lasound -lrt
+LIBS	= -lz -lpthread -lm -lpthread -lSDL -L/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound -lrt
 
 TAR		= tar -cf
 GZIP	= gzip -9f


### PR DESCRIPTION
It probably won't make sense to try to get this fork of fbalpha working on the mesa driver, so we can add "!mesa" to the rp_module_flags. If it can be made to work on fkms, we can address that when it's appropriate.